### PR TITLE
Well known support with new Info field

### DIFF
--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/keys.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/keys.go
@@ -185,7 +185,7 @@ func CheckKeys(serverName ServerName, now time.Time, keys ServerKeys, connState 
 
 	// Only check the fingerprint if we have the TLS connection state.
 	if connState != nil {
-		// Check the peer certificates.
+		// Check the peer certificatesMSC.
 		matches := checkFingerprint(connState, sha256Fingerprints)
 		checks.MatchingTLSFingerprint = &matches
 		checks.AllChecksOK = checks.AllChecksOK && matches


### PR DESCRIPTION
Adds a new `Info` field which can be used for checks that aren't essential for federation (it's OK if they're `false`). Regular `Check` functionality remains the same.

Inside this `Info` field is a new check for `.well-known` support as defined by [this MSC](https://github.com/matrix-org/matrix-doc/blob/de57d3950f0fb1fe7b0a9d21877d5e699709df36/proposals/1708-well-known-for-federation.md).