### PR TITLE
Add field for reporting descriptive errors during testing

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -84,11 +84,6 @@ type Info struct {
 	WellKnownInUse bool // Whether the server is using .well-known
 }
 
-// Errors is a slice of human readable errors encoded as strings.
-// Inclusion in this slice are errors which help better explain why a specific
-// check failed.
-type Errors []error
-
 // A ConnectionReport is information about a connection made to a matrix server.
 type ConnectionReport struct {
 	Certificates      []X509CertSummary                                          // Summary information for each x509 certificate served up by this server.
@@ -96,7 +91,7 @@ type ConnectionReport struct {
 	Keys              *json.RawMessage                                           // The server key JSON returned by this server.
 	Checks            gomatrixserverlib.KeyChecks                                // Checks applied to the server and their results.
 	Info              Info                                                       // Checks that are not necessary to pass, rather simply informative.
-	Errors            Errors                                                     // String slice describing any problems encountered during testing.
+	Errors            []errors                                                   // String slice describing any problems encountered during testing.
 	Ed25519VerifyKeys map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64String // The Verify keys for this server or nil if the checks were not ok.
 	ValidCertificates bool                                                       // The X509 certificates have been verified by the system root CAs.
 }

--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -84,7 +84,7 @@ type Info struct {
 	WellKnownInUse bool // Whether the server is using .well-known
 }
 
-// Errors is a slice of human-readable errors encoded as strings.
+// Errors is a slice of human readable errors encoded as strings.
 // Inclusion in this slice are errors which help better explain why a specific
 // check failed.
 type Errors []error
@@ -148,7 +148,7 @@ func Report(
 			continue
 		}
 		var connReport ConnectionReport
-		// Slice of human-readable errors found during testing.
+		// Slice of human readable errors found during testing.
 		connReport.Errors = make([]error, 0, 0)
 
 		// Check for valid X509 certificate

--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -91,7 +91,7 @@ type ConnectionReport struct {
 	Keys              *json.RawMessage                                           // The server key JSON returned by this server.
 	Checks            gomatrixserverlib.KeyChecks                                // Checks applied to the server and their results.
 	Info              Info                                                       // Checks that are not necessary to pass, rather simply informative.
-	Errors            []errors                                                   // String slice describing any problems encountered during testing.
+	Errors            []error                                                    // String slice describing any problems encountered during testing.
 	Ed25519VerifyKeys map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64String // The Verify keys for this server or nil if the checks were not ok.
 	ValidCertificates bool                                                       // The X509 certificates have been verified by the system root CAs.
 }


### PR DESCRIPTION
Provides a field for exposing human-readable errors in the output JSON. Hook up to `IsValidCertificates`. Will initially use for describing problems with Well-Known lookup and cert validation.