### PR TITLE
Fix issue with certs not being marked as valid for SRV

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -144,6 +144,7 @@ func Report(
 		var connReport ConnectionReport
 
 		// Check for valid X509 certificate
+		DNSNames := make([]gomatrixserverlib.ServerName, 0, 0)
 		intermediateCerts := x509.NewCertPool()
 		var directCert *x509.Certificate
 		for _, cert := range connState.PeerCertificates {
@@ -152,11 +153,14 @@ func Report(
 				intermediateCerts.AddCert(cert)
 			} else {
 				directCert = cert
+				for _, DNSName := range cert.DNSNames {
+					DNSNames = append(DNSNames, gomatrixserverlib.ServerName(DNSName))
+				}
 			}
 		}
 
 		if directCert != nil {
-			valid, _ := gomatrixserverlib.IsValidCertificate(serverName, directCert, intermediateCerts)
+			valid, _ := gomatrixserverlib.IsValidCertificate(DNSNames, directCert, intermediateCerts)
 			connReport.ValidCertificates = valid
 		}
 

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/certificates.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/certificates.go
@@ -6,10 +6,10 @@ import (
 
 // IsValidCertificate checks if the given x509 certificate can be verified using
 // system root CAs and an optional pool of intermediate CAs.
-func IsValidCertificate(serverNames []ServerName, c *x509.Certificate, intermediates *x509.CertPool) (valid bool, err error) {
+func IsValidCertificate(serverNames []ServerName, c *x509.Certificate, intermediates *x509.CertPool) (bool, error) {
 	for _, serverName := range serverNames {
 		verificationOpts := x509.VerifyOptions{
-			DNSName: string(serverName),
+			DNSName:       string(serverName),
 			Intermediates: intermediates,
 		}
 		roots, err := c.Verify(verificationOpts)
@@ -20,5 +20,5 @@ func IsValidCertificate(serverNames []ServerName, c *x509.Certificate, intermedi
 		}
 	}
 
-	return false, err
+	return false, nil
 }

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/certificates.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/certificates.go
@@ -6,12 +6,19 @@ import (
 
 // IsValidCertificate checks if the given x509 certificate can be verified using
 // system root CAs and an optional pool of intermediate CAs.
-func IsValidCertificate(serverName ServerName, c *x509.Certificate, intermediates *x509.CertPool) (valid bool, err error) {
-	verificationOpts := x509.VerifyOptions{
-		DNSName:       string(serverName),
-		Intermediates: intermediates,
+func IsValidCertificate(serverNames []ServerName, c *x509.Certificate, intermediates *x509.CertPool) (valid bool, err error) {
+	for _, serverName := range serverNames {
+		verificationOpts := x509.VerifyOptions{
+			DNSName: string(serverName),
+			Intermediates: intermediates,
+		}
+		roots, err := c.Verify(verificationOpts)
+		if err != nil {
+			return false, err
+		} else if len(roots) > 0 {
+			return true, err
+		}
 	}
-	roots, err := c.Verify(verificationOpts)
 
-	return len(roots) > 0, err
+	return false, err
 }

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/keys.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/keys.go
@@ -161,7 +161,7 @@ type KeyChecks struct {
 }
 
 // CheckKeys checks the keys returned from a server to make sure they are valid.
-// If the checks pass then also return a map of key_id to Ed25519 public key and a list of SHA256 TLS fingerprints.
+// If the checks pass then also return a map of key_id to Ed25519 public key
 func CheckKeys(
 	serverName ServerName,
 	now time.Time,


### PR DESCRIPTION
The valid certification checker would not work properly if you were using SRV instead of well-known. We know do a well-known check -> SRV check -> certificate check. The previous method skipped the result of the SRV check in the certificate check.

We're now passing multiple domain names to the cert checker, and if any of them succeed report that certs are working. This seems like a working solution? Not sure if there's any edge case where this causes a false positive but open to feedback :)

Paired with: https://github.com/matrix-org/gomatrixserverlib/pull/111