### PR TITLE
Add minimum Go version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Checks that federation is correctly configured on a matrix server.
 Building
 --------
 
-The tester is written in [golang](https://golang.org/) and built using [gb](https://getgb.io).
+The tester is written in [golang](https://golang.org/) 1.10+ and built using [gb](https://getgb.io).
 
 ```bash
 go get github.com/constabulary/gb/...


### PR DESCRIPTION
May want to specify we're testing against Go 1.10 and it is the recommended version.