### PR TITLE
Print well-known result information

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -72,15 +72,15 @@ func main() {
 
 // A ServerReport is a report for a matrix server.
 type ServerReport struct {
-	WellKnownResult   WellKnownResult             // The result of looking up the server's .well-known/matrix/server file.
+	WellKnownResult   WellKnownReport             // The result of looking up the server's .well-known/matrix/server file.
 	DNSResult         gomatrixserverlib.DNSResult // The result of looking up the server in DNS.
 	ConnectionReports map[string]ConnectionReport // The report for each server address we could connect to.
 	ConnectionErrors  map[string]error            // The errors for each server address we couldn't connect to.
 }
 
-// A WellKnownResult is the combination of data from a matrix server's
+// A WellKnownReport is the combination of data from a matrix server's
 // .well-known file, as well as any errors reported during the lookup.
-type WellKnownResult struct {
+type WellKnownReport struct {
 	ServerAddress gomatrixserverlib.ServerName `json:"m.server"`
 	Error string `json:"error,omitempty"`
 }

--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -79,7 +79,7 @@ type ServerReport struct {
 }
 
 // A WellKnownResult is the combination of data from a matrix server's
-// .well-known file, as well as any error's reported during the lookup.
+// .well-known file, as well as any errors reported during the lookup.
 type WellKnownResult struct {
 	ServerAddress gomatrixserverlib.ServerName `json:"m.server"`
 	Error string `json:"error,omitempty"`

--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -120,8 +120,8 @@ func Report(
 	var report ServerReport
 
 	// Check for .well-known
-	if report.WellKnownResult = gomatrixserverlib.LookupWellKnown(serverName); report.WellKnownResult.Error == "" {
-		fmt.Println(report.WellKnownResult)
+	var err error
+	if report.WellKnownResult, err = gomatrixserverlib.LookupWellKnown(serverName); err == nil {
 		// Use well-known as new host
 		serverHost = report.WellKnownResult.NewAddress
 	}

--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -72,9 +72,10 @@ func main() {
 
 // A ServerReport is a report for a matrix server.
 type ServerReport struct {
-	DNSResult         gomatrixserverlib.DNSResult // The result of looking up the server in DNS.
-	ConnectionReports map[string]ConnectionReport // The report for each server address we could connect to.
-	ConnectionErrors  map[string]error            // The errors for each server address we couldn't connect to.
+	WellKnownResult   gomatrixserverlib.WellKnownResult // The result of looking up the server's .well-known/matrix/server file.
+	DNSResult         gomatrixserverlib.DNSResult       // The result of looking up the server in DNS.
+	ConnectionReports map[string]ConnectionReport       // The report for each server address we could connect to.
+	ConnectionErrors  map[string]error                  // The errors for each server address we couldn't connect to.
 }
 
 // Info is a struct that contains federation checks that are not necessary in
@@ -116,16 +117,15 @@ func Report(
 ) (*ServerReport, error) {
 	// Host address of the server (can be different from the serverName through SRV/well-known)
 	serverHost := serverName
+	var report ServerReport
 
 	// Check for .well-known
-	var err error
-	var wellKnown *gomatrixserverlib.WellKnownResult
-	if wellKnown, err = gomatrixserverlib.LookupWellKnown(serverName); err == nil {
+	if report.WellKnownResult = gomatrixserverlib.LookupWellKnown(serverName); report.WellKnownResult.Error == "" {
+		fmt.Println(report.WellKnownResult)
 		// Use well-known as new host
-		serverHost = wellKnown.NewAddress
+		serverHost = report.WellKnownResult.NewAddress
 	}
 
-	var report ServerReport
 	dnsResult, err := gomatrixserverlib.LookupServer(serverHost)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func Report(
 		connReport.Cipher.Version = enumToString(tlsVersions, connState.Version)
 		connReport.Cipher.CipherSuite = enumToString(tlsCipherSuites, connState.CipherSuite)
 		connReport.Checks, connReport.Ed25519VerifyKeys = gomatrixserverlib.CheckKeys(serverName, now, *keys)
-		connReport.Info = infoChecks(serverName, wellKnown)
+		connReport.Info = infoChecks(serverName, report.WellKnownResult)
 		raw := json.RawMessage(keys.Raw)
 		connReport.Keys = &raw
 		report.ConnectionReports[addr] = connReport
@@ -189,13 +189,13 @@ func Report(
 
 // infoChecks are checks that are not required for federation, just good-to-knows
 func infoChecks(
-	serverName gomatrixserverlib.ServerName, wellKnown *gomatrixserverlib.WellKnownResult,
+	serverName gomatrixserverlib.ServerName, wellKnown gomatrixserverlib.WellKnownResult,
 ) Info {
 	info := Info{}
 
 	// Well-known is checked earlier for redirecting the test servername, so just
 	// reuse that result
-	info.WellKnownInUse = (wellKnown != nil)
+	info.WellKnownInUse = (wellKnown.NewAddress != "")
 
 	return info
 }

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/well_known.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/well_known.go
@@ -34,7 +34,8 @@ func LookupWellKnown(serverNameType ServerName) (*WellKnownResult, error) {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != 200 {
-		return nil, errors.New("No .well-known found")
+		err = errors.New("No .well-known found")
+		return nil, err
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Prints error information for .well-known lookups:

![image](https://user-images.githubusercontent.com/1342360/52736346-91092500-2fc1-11e9-847f-9c122ac92881.png)

---

![image](https://user-images.githubusercontent.com/1342360/52736332-85b5f980-2fc1-11e9-8d31-5f8784abf968.png)

---

![image](https://user-images.githubusercontent.com/1342360/52736369-9e261400-2fc1-11e9-98e2-9a69d3dd6a7e.png)