### PR TITLE
Infer SNI from serverHost

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -147,7 +147,8 @@ func Report(
 	report.ConnectionErrors = make(map[string]error)
 	now := time.Now()
 	for _, addr := range report.DNSResult.Addrs {
-		keys, connState, err := gomatrixserverlib.FetchKeysDirect(serverHost, addr, string(serverHost))
+		host, _, _ := gomatrixserverlib.ParseAndValidateServerName(serverHost)
+		keys, connState, err := gomatrixserverlib.FetchKeysDirect(serverHost, addr, host)
 		if err != nil {
 			report.ConnectionErrors[addr] = err
 			continue

--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -82,7 +82,7 @@ type ServerReport struct {
 // .well-known file, as well as any errors reported during the lookup.
 type WellKnownReport struct {
 	ServerAddress gomatrixserverlib.ServerName `json:"m.server"`
-	Error string `json:"error,omitempty"`
+	Error         string                       `json:"error,omitempty"`
 }
 
 // Info is a struct that contains federation checks that are not necessary in


### PR DESCRIPTION
This sets the SNI to whatever `serverHost` is, which should be "example.com", or in the case of .well-known in use, something like "matrix.example.com".

Please let me know if I misunderstood how SNI works :)

Fixes #28 