### PR TITLE
Remove newlines in non-output print statements

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -134,7 +134,7 @@ func Report(
 	// Validate the server name, and retrieve domain name to send as SNI to server
 	sni, _, valid := gomatrixserverlib.ParseAndValidateServerName(serverHost)
 	if !valid {
-		report.Error = fmt.Sprintf("Invalid server name '%s'\n", serverHost)
+		report.Error = fmt.Sprintf("Invalid server name '%s'", serverHost)
 		return
 	}
 
@@ -148,7 +148,7 @@ func Report(
 		// need to revalidate the server name and update the SNI
 		sni, _, valid = gomatrixserverlib.ParseAndValidateServerName(serverHost)
 		if !valid {
-			report.Error = fmt.Sprintf("Invalid server name '%s' in .well-known result\n", serverHost)
+			report.Error = fmt.Sprintf("Invalid server name '%s' in .well-known result", serverHost)
 			return
 		}
 	} else {
@@ -265,7 +265,7 @@ func enumToString(names map[uint16]string, value uint16) string {
 	if name, ok := names[value]; ok {
 		return name
 	}
-	return fmt.Sprintf("UNKNOWN[0x%x]\n", value)
+	return fmt.Sprintf("UNKNOWN[0x%x]", value)
 }
 
 var (


### PR DESCRIPTION
Reverts changes in https://github.com/matrix-org/matrix-federation-tester/pull/51 that added newlines that weren't necessary.