### PR TITLE
check correct err result from connCheck

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -170,7 +170,7 @@ func Report(
 	for _, addr := range report.DNSResult.Addrs {
 		if connReport, connErr := connCheck(
 			addr, serverHost, serverName, sni, wellKnownResult,
-		); err != nil {
+		); connErr != nil {
 			report.ConnectionErrors[addr] = connErr
 		} else {
 			report.ConnectionReports[addr] = *connReport


### PR DESCRIPTION
code crashes for non matrix domains or not responding matrix servers
(error 524 on https://matrix.org/federationtester/api/report?server_name=nonmatrix.domain)