### PR TITLE
Change error to result in wellknownreport. Less scary if no well-known

### DIFF
--- a/src/github.com/matrix-org/matrix-federation-tester/main.go
+++ b/src/github.com/matrix-org/matrix-federation-tester/main.go
@@ -97,7 +97,7 @@ type VersionReport struct {
 // .well-known file, as well as any errors reported during the lookup.
 type WellKnownReport struct {
 	ServerAddress gomatrixserverlib.ServerName `json:"m.server"`
-	Error         string                       `json:"error,omitempty"`
+	Result        string                       `json:"result,omitempty"`
 }
 
 // Info is a struct that contains federation checks that are not necessary in
@@ -167,7 +167,7 @@ func Report(
 			return
 		}
 	} else {
-		report.WellKnownResult.Error = err.Error()
+		report.WellKnownResult.Result = err.Error()
 	}
 
 	// Lookup server version


### PR DESCRIPTION
Users no longer see:

```
  "WellKnownResult": {
    "m.server": "",
    "error": "No .well-known found"
  },
```

but instead:

```
  "WellKnownResult": {
    "m.server": "",
    "result": "No .well-known found"
  },
```

Closes #50