### PR TITLE
Add json report field to show when the dns lookup was skipped

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ type WellKnownReport struct {
 
 // A DNSResult is the result of looking up a matrix server in DNS.
 type DNSResult struct {
+	Skipped    bool                  // When the DNS lookup has been skiped due to a port declaration inside the .well-known address.
 	SRVCName   string                // The canonical name for the SRV record in DNS
 	SRVRecords []*net.SRV            // List of SRV record for the matrix server.
 	SRVError   error                 // If there was an error getting the SRV records.
@@ -344,6 +345,7 @@ func lookupServer(serverName gomatrixserverlib.ServerName) (*DNSResult, error) {
 			Target: host,
 			Port:   uint16(port),
 		}}
+		result.Skipped = true
 	}
 
 	// Look up the IP addresses for each host.

--- a/main.go
+++ b/main.go
@@ -131,7 +131,7 @@ type WellKnownReport struct {
 
 // A DNSResult is the result of looking up a matrix server in DNS.
 type DNSResult struct {
-	Skipped    bool                  // When the DNS lookup has been skiped due to a port declaration inside the .well-known address.
+	SRVSkipped bool                  // True if the SRV record lookup was skipped due to the server name or .well-known target including a port number.
 	SRVCName   string                // The canonical name for the SRV record in DNS
 	SRVRecords []*net.SRV            // List of SRV record for the matrix server.
 	SRVError   error                 // If there was an error getting the SRV records.
@@ -345,7 +345,7 @@ func lookupServer(serverName gomatrixserverlib.ServerName) (*DNSResult, error) {
 			Target: host,
 			Port:   uint16(port),
 		}}
-		result.Skipped = true
+		result.SRVSkipped = true
 	}
 
 	// Look up the IP addresses for each host.


### PR DESCRIPTION
This field should clarify when a '.well-known' information with a port
declaration was found, that the dns lookup was skipped.
The field can befound inside the 'DNSResult' object with the name
'Skipped' and is from type boolean.

To give some context:
This change was made based on a Pull-Request inside the 'fed-tester-ui'
project [1] to show a proper message to the user inside the UI
explaining the missing SRV records information.

Relates to issue #104.

Refs:
  - [1] https://github.com/matrix-org/fed-tester-ui/pull/26