### PR TITLE
Unset `FederationOK` in more cases

### DIFF
--- a/main.go
+++ b/main.go
@@ -227,7 +227,6 @@ func Report(
 		}
 	} else {
 		report.WellKnownResult.Result = err.Error()
-		
 	}
 
 	// Lookup server version

--- a/main.go
+++ b/main.go
@@ -206,6 +206,7 @@ func Report(
 	sni, _, valid := gomatrixserverlib.ParseAndValidateServerName(serverHost)
 	if !valid {
 		report.Error = fmt.Sprintf("Invalid server name '%s'", serverHost)
+		report.FederationOK = false
 		return
 	}
 
@@ -221,10 +222,12 @@ func Report(
 		sni, _, valid = gomatrixserverlib.ParseAndValidateServerName(serverHost)
 		if !valid {
 			report.Error = fmt.Sprintf("Invalid server name '%s' in .well-known result", serverHost)
+			report.FederationOK = false
 			return
 		}
 	} else {
 		report.WellKnownResult.Result = err.Error()
+		
 	}
 
 	// Lookup server version
@@ -235,6 +238,7 @@ func Report(
 		report.Version.Version = version.Server.Version
 	} else {
 		report.Version.Error = err.Error()
+		report.FederationOK = false
 	}
 
 	dnsResult, err := lookupServer(serverHost)


### PR DESCRIPTION
It looks like providing invalid server names, invalid names in the well-known `m.server` field or the server not responding to a federation request, will still return `FederationOK: true`.