### PR TITLE
Set `ReadHeaderTimeout` on the HTTP server

### DIFF
--- a/main.go
+++ b/main.go
@@ -99,8 +99,12 @@ func JSONReport(
 func main() {
 	http.HandleFunc("/api/report", prometheus.InstrumentHandlerFunc("report", HandleReport))
 	http.Handle("/metrics", prometheus.Handler())
+	server := &http.Server{
+		Addr:              os.Getenv("BIND_ADDRESS"),
+		ReadHeaderTimeout: 3 * time.Second,
+	}
 	// ListenAndServe always returns a non-nil error so we want to panic here.
-	panic(http.ListenAndServe(os.Getenv("BIND_ADDRESS"), nil))
+	panic(server.ListenAndServe())
 }
 
 // A ServerReport is a report for a matrix server.


### PR DESCRIPTION
This should hopefully satisfy the `G114: Use of net/http serve function that has no support for setting timeouts (gosec)` lint error by ensuring that we drop connections from clients that don't send a fully-formed HTTP request quickly enough.