### PR TITLE
Add `gomatrixserverlib.WithWellKnownSRVLookups` to `NewClient`

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,7 +236,9 @@ func Report(
 	}
 
 	// Lookup server version
-	client := gomatrixserverlib.NewClient()
+	client := gomatrixserverlib.NewClient(
+		gomatrixserverlib.WithWellKnownSRVLookups(true),
+	)
 	version, err := client.GetVersion(ctx, serverName)
 	if err == nil {
 		report.Version.Name = version.Server.Name


### PR DESCRIPTION
The API shape changed for GMSL in matrix-org/gomatrixserverlib#304 to allow us to control whether `gomatrixserverlib.Client` performs well-known/SRV lookups or not. The `gomatrixserverlib.FederationClient` defaults to enabled for this but `gomatrixserverlib.Client` does not.

So it is right after all to pass in the vanity name to `GetVersion`, but if the client isn't configured to look up well-known, it'll obviously do the wrong thing.

Fixes #128.