### PR TITLE
Update golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 run:
   deadline: 5m
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     - hooks
     - scripts
 
@@ -11,14 +13,12 @@ linters:
    - goconst
    - gocyclo
    - goimports
-   - golint
    - gosec
+   - govet
    - ineffassign
-   - maligned
    - misspell
-   - structcheck
+   - revive
    - unconvert
    - unparam
-   - varcheck
-   - vet
-   - vetshadow
+   - unused
+

--- a/promutils/prom_handlers.go
+++ b/promutils/prom_handlers.go
@@ -23,7 +23,7 @@ type InstrumentationMiddleware interface {
 
 type nopInstrumentationMiddleware struct{}
 
-func (ins nopInstrumentationMiddleware) NewHandler(handlerName string, handler http.Handler) http.HandlerFunc {
+func (ins nopInstrumentationMiddleware) NewHandler(_ string, handler http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handler.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
It seems that there have been some changes to golangci-lint over the last couple of years. Update config to make it pass again.